### PR TITLE
Corrected the yaw controller

### DIFF
--- a/src/turbines/turbines_phys.c
+++ b/src/turbines/turbines_phys.c
@@ -592,9 +592,11 @@ PetscErrorCode controlNacYaw(farm_ *farm)
                             // rotate common parameters
                             mRot(wt->twrDir, wt->rtrDir,    angle);
                             mRot(wt->twrDir, wt->rtrAxis,   angle);
+			    mSub(wt->rotCenter, wt->twrTop);
                             mRot(wt->twrDir, wt->rotCenter, angle);
-
-                            // actuator disk model
+                            mSum(wt->rotCenter, wt->twrTop);
+                            
+			    // actuator disk model
                             if((*farm->turbineModels[t]) == "ADM")
                             {
                                 // number of points in the AD mesh


### PR DESCRIPTION
Corrected the yaw controller, which was creating error in the ADM turbine force and power when the yaw controller was active. The new yaw controller is implemented in src/turbines/turbines_phys.c. The fix applies rotation of the rotor center about the tower top. The fix was tested on the single-turbine NREL 5MW and ten-turbine NREL 5MW in the HKN wind farm array. The fix corrects the unphysical behavior in the turbine force that was randomly turning the turbines on and off when the yaw controller was active.