### PR TITLE
Fixing another uninitialized tRef

### DIFF
--- a/src/teqn.c
+++ b/src/teqn.c
@@ -299,7 +299,18 @@ PetscErrorCode ghGradRhoK(teqn_ *teqn)
     PetscInt      i, j, k;
     PetscInt      lxs, lxe, lys, lye, lzs, lze;
 
-    const PetscReal  g = -9.81, tRef = ueqn->access->abl->tRef;;
+    const PetscReal  g = -9.81;
+    PetscReal  tRef;
+    
+    // Use tRef from ABLProperties.dat if ABL is active
+    if (teqn->access->flags->isAblActive) 
+    {
+        tRef = teqn->access->abl->tRef;
+    } // Use tRef from control.dat if ABL is not active
+    else
+    {
+        tRef = teqn->access->constants->tRef;
+    }
 
     PetscReal     dbdc, dbde, dbdz;
 


### PR DESCRIPTION
This fixes an uninitialized reference to `tRef `in `teqn.c` when conducting a simulation with the potential temperature equation on but the ABL is not initialized. It reverts to using `tRef` defined in control.dat when ABL is not active.