### PR TITLE
User-defined power law exponent

### DIFF
--- a/src/boundary.c
+++ b/src/boundary.c
@@ -1238,10 +1238,11 @@ PetscErrorCode UpdateCartesianBCs(ueqn_ *ueqn)
                         PetscReal z = cent[k][j][i].z;
 
                         // shear exponent
-                        PetscReal alpha = 0.107027;
+                        //PetscReal alpha = 0.107027;
+
 
                         // power low contribution
-                        ucat[k-1][j][i] = nScale(pow(h/ifPtr->Href, alpha), ifPtr->Uref);
+                        ucat[k-1][j][i] = nScale(pow(h/ifPtr->Href, ifPtr->alpha), ifPtr->Uref);
 
                         // fluctuations contribution
                         PetscReal f          = ifPtr->uPrimeRMS;

--- a/src/include/boundary.h
+++ b/src/include/boundary.h
@@ -65,6 +65,7 @@ struct inletFunctionTypes
     Cmpnts        Uref;
     PetscReal     Href;
     PetscReal     uPrimeRMS;
+    PetscReal     alpha;
 
     // type 2/5: log law/with veer + neutral stratification
     Cmpnts        Udir;                       //!< velocity direction vector

--- a/src/inflow.c
+++ b/src/inflow.c
@@ -60,6 +60,7 @@ PetscErrorCode SetInflowFunctions(mesh_ *mesh)
             readSubDictVector(fileName.c_str(), "inletFunction", "Uref", &(ifPtr->Uref));
             readSubDictDouble(fileName.c_str(), "inletFunction", "Href", &(ifPtr->Href));
             readSubDictDouble(fileName.c_str(), "inletFunction", "uPrimeRMS", &(ifPtr->uPrimeRMS));
+            readSubDictDouble(fileName.c_str(), "inletFunction", "alpha", &(ifPtr->alpha));
         }
         // log law profile
         else if (ifPtr->typeU == 2)


### PR DESCRIPTION
I modified inlet function number 1 to accept a user-specified power-law exponent in the `boundary/U/kLeft` dictionary entry.